### PR TITLE
googlefontsの導入

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP" rel="stylesheet">
+    <title>Discord Clone</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,6 @@
 * {
   margin: 0;
+  font-family: "Noto Sans JP";
 }
 
 body {


### PR DESCRIPTION
## 変更理由
* フォントの変更でアプリのフォントの見やすさを向上するため
## 変更内容
* google fonts japaneseの`<link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP" rel="stylesheet">`をindex.htmlに追加
* google fonts japaneseの`font-family: "Noto Sans JP";`をindex.scssに追加